### PR TITLE
Registry.load is now chainable

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -58,6 +58,8 @@ Registry.prototype = {
         if (options.tasks) {
             this._loadTasks(options.tasks);
         }
+        
+        return this;
     },
 
     _loadModule: function(name) {

--- a/test/registry.js
+++ b/test/registry.js
@@ -5,5 +5,15 @@ describe('Registry', function() {
         it('should load modules');
         it('should load directories');
         it('should load files');
+        
+        it('should allow for chaining #load', function() {
+            var registry = new Registry();
+            
+            registry.load({
+                tasks : {
+                    fooga : function() {}
+                }
+            }).tasks.should.eql(registry.tasks);
+        });
     });
 });


### PR DESCRIPTION
To ease loading lots of tasks into a single Registry, since Queue can't take multiple Registries.

Before change:

``` javascript
// constructor loads anything in "./tasks"
var registry = new Registry()
    // load gear-lib tasks from npm module
    .load({ module : "gear-lib" });

typeof registry; // "undefined"
```

After:

``` javascript
// constructor loads anything in "./tasks"
var registry = new Registry()
    // load gear-lib tasks from npm module
    .load({ module : "gear-lib" });

typeof registry; // "object"
```
