### PR TITLE
Fix typo of Util export

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,4 +9,4 @@ var lib = process.env.GEAR_COVER ? './lib-cov/' : './lib/';
 exports.Registry = require(lib + 'registry').Registry;
 exports.Queue = require(lib + 'queue').Queue;
 exports.Blob = require(lib + 'blob').Blob;
-exports.Util = require(lib + 'Util');
+exports.Util = require(lib + 'util');


### PR DESCRIPTION
I think this is a typo. Error I got before this fix.

Error: Cannot find module './lib/Util'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/weiwei/cloud-console-fe/tools/node_modules/gear/index.js:12:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
