### PR TITLE
Delete CNAME as gearjs.org is gone

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gearjs.org


### PR DESCRIPTION
This enables https://twobit.github.io/gear .